### PR TITLE
proposal: get rid of string literals

### DIFF
--- a/mads-experiments/src/main/kotlin/org/jetbrains/research/mads/experiments/training/Topology.kt
+++ b/mads-experiments/src/main/kotlin/org/jetbrains/research/mads/experiments/training/Topology.kt
@@ -10,33 +10,42 @@ import org.jetbrains.research.mads.ns.physiology.neurons.Neuron
 import org.jetbrains.research.mads.providers.MnistProvider
 import java.util.*
 
-fun mnistTopology(
-    provider: MnistProvider,
-    excNeuronFun: () -> Neuron,
-    inhNeuronFun: () -> Neuron,
-    nExc: Int
-): List<ModelObject> {
-    val inputNeuron2DGrid = InputNeuron2DGrid(provider, 10.0)
-    inputNeuron2DGrid.type = "inputLayer"
-    val secondLayer: List<Neuron> = createPopulation(nExc, "secondLayer", excNeuronFun)
-    val thirdLayer: List<Neuron> = createPopulation(nExc, "thirdLayer", inhNeuronFun)
+class Topology {
+    companion object {
+        const val INPUT_LAYER = "inputLayer"
+        const val SECOND_LAYER = "secondLayer"
+        const val OUTPUT_LAYER = "thirdLayer"
 
-    val rnd = Random(42L)
+        fun mnistTopology(
+            provider: MnistProvider,
+            excNeuronFun: () -> Neuron,
+            inhNeuronFun: () -> Neuron,
+            nExc: Int
+        ): List<ModelObject> {
+            val inputNeuron2DGrid = InputNeuron2DGrid(provider, 10.0)
+            inputNeuron2DGrid.type = INPUT_LAYER
+            val secondLayer: List<Neuron> = createPopulation(nExc, SECOND_LAYER, excNeuronFun)
+            val thirdLayer: List<Neuron> = createPopulation(nExc, OUTPUT_LAYER, inhNeuronFun)
 
-    val synapses1to2 =
-        connectPopulations(inputNeuron2DGrid.getNeurons(), secondLayer, probability = 1.0, rnd = rnd,
-            weight = { rnd.nextDouble() / 2 }, delay = { rnd.nextInt(100) })
-    val synapses2to3 = connectPopulationsOneToOne(secondLayer, thirdLayer, weight = { 5.0 }, delay = { 0 })
-    val synapses3to2 = connectPopulationsInhibition(thirdLayer, secondLayer, weight = { 5.0 }, delay = { 0 })
+            val rnd = Random(42L)
 
-    val objects: ArrayList<ModelObject> = arrayListOf()
-    objects.add(inputNeuron2DGrid)
-    objects.addAll(inputNeuron2DGrid.getNeurons())
-    objects.addAll(secondLayer)
-    objects.addAll(thirdLayer)
-    objects.addAll(synapses1to2)
-    objects.addAll(synapses2to3)
-    objects.addAll(synapses3to2)
+            val synapses1to2 =
+                connectPopulations(inputNeuron2DGrid.getNeurons(), secondLayer, probability = 1.0, rnd = rnd,
+                    weight = { rnd.nextDouble() / 2 }, delay = { rnd.nextInt(100) })
+            val synapses2to3 = connectPopulationsOneToOne(secondLayer, thirdLayer, weight = { 5.0 }, delay = { 0 })
+            val synapses3to2 = connectPopulationsInhibition(thirdLayer, secondLayer, weight = { 5.0 }, delay = { 0 })
 
-    return objects
+            val objects: ArrayList<ModelObject> = arrayListOf()
+            objects.add(inputNeuron2DGrid)
+            objects.addAll(inputNeuron2DGrid.getNeurons())
+            objects.addAll(secondLayer)
+            objects.addAll(thirdLayer)
+            objects.addAll(synapses1to2)
+            objects.addAll(synapses2to3)
+            objects.addAll(synapses3to2)
+
+            return objects
+        }
+    }
 }
+

--- a/mads-experiments/src/main/kotlin/org/jetbrains/research/mads/experiments/training/izh/izhMNIST.kt
+++ b/mads-experiments/src/main/kotlin/org/jetbrains/research/mads/experiments/training/izh/izhMNIST.kt
@@ -4,7 +4,7 @@ import org.jetbrains.research.mads.core.configuration.Configuration
 import org.jetbrains.research.mads.core.simulation.Model
 import org.jetbrains.research.mads.core.telemetry.FileSaver
 import org.jetbrains.research.mads.core.types.ModelObject
-import org.jetbrains.research.mads.experiments.training.mnistTopology
+import org.jetbrains.research.mads.experiments.training.Topology
 import org.jetbrains.research.mads.ns.physiology.neurons.*
 import org.jetbrains.research.mads.providers.MnistProvider
 import java.nio.file.Paths
@@ -18,16 +18,16 @@ fun main() {
 
 fun mnist3Phase() {
     val startTime = System.currentTimeMillis()
-    val trainClassSize = 20 // per class
-    val assignClassSize = 20 // per class
-    val testClassSize = 20 // per class
+    val trainClassSize = 1 // per class
+    val assignClassSize = 1 // per class
+    val testClassSize = 1 // per class
     val nExc = 64
 
     val targetClasses = listOf("1", "0")
     // TODO use relative path
     val dataDir = Paths.get("data/MNIST_training/")
     val provider = MnistProvider(dataDir.absolutePathString(), targetClasses)
-    val topology = mnistTopology(
+    val topology = Topology.mnistTopology(
         provider,
         { -> IzhNeuron(IzhRS, adaptiveThreshold = true, weightNormalizationEnabled = true) },
         { -> IzhNeuron(IzhFS, adaptiveThreshold = false, weightNormalizationEnabled = false) },
@@ -49,14 +49,14 @@ fun mnist3Phase() {
     learningPhase(
         logFolder = "assign/${startTime}",
         listOf(SpikesSignals::spiked, CurrentStimuli::stimuli),
-        listOf("inputLayer", "secondLayer"),
+        listOf(Topology.INPUT_LAYER, Topology.SECOND_LAYER),
         topology,
         testPhaseConfig()
     ) { provider.imageIndex >= trainSize + assignSize }
     learningPhase(
         logFolder = "test/${startTime}",
         listOf(SpikesSignals::spikeCounter, CurrentStimuli::stimuli),
-        listOf("inputLayer", "secondLayer"),
+        listOf(Topology.INPUT_LAYER, Topology.SECOND_LAYER),
         topology,
         testPhaseConfig()
     ) { provider.imageIndex >= trainSize + assignSize + testSize }


### PR DESCRIPTION
get rid of string literal names of neuron layers, use static variables instead